### PR TITLE
Disable unused flag

### DIFF
--- a/mdcs/core_settings.py
+++ b/mdcs/core_settings.py
@@ -179,6 +179,6 @@ GA_TRACKING_ID = os.getenv("GA_TRACKING_ID", None)
 """ :py:class:`str`: Google Analytics tracking ID. Adds gtag to user pages if set.
 """
 
-CAN_ANONYMOUS_ACCESS_PUBLIC_DOCUMENT = True
+CAN_ANONYMOUS_ACCESS_PUBLIC_DOCUMENT = False
 """ :py:class:`bool`: Can anonymous user access public document.
 """


### PR DESCRIPTION
Disables unused flag CAN_ANONYMOUS_ACCESS_PUBLIC_DOCUMENT which was enabled to allow for the download feature.